### PR TITLE
Harden ARP scanner interface and scope handling

### DIFF
--- a/arpscanner/arpscanner.py
+++ b/arpscanner/arpscanner.py
@@ -1,79 +1,228 @@
-"""
-Script Name: Network ARP Scanner
-Author: Antonio Flores
-Date: 2026-07-14
-Version: 1.3
+#!/usr/bin/env python3
+"""Discover IPv4 hosts on directly connected networks with ARP requests."""
 
-Description:
-    This script performs an ARP scan on the local network to identify active devices.
-    It lists each device's IP and MAC address.
+from __future__ import annotations
 
-Usage:
-    Run the script with Python 3. Requires 'scapy' and 'netifaces' libraries. Requires sudo.
-
-Disclaimer:
-    This script is for educational purposes only. Ensure you have authorization before scanning any network.
-"""
-
-import scapy.all as scapy
-import netifaces as ni
+import argparse
 import ipaddress
+import os
+import sys
+from collections.abc import Iterable
 
-def scan(ip):
-    arp_request = scapy.ARP(pdst=ip)
-    broadcast = scapy.Ether(dst="ff:ff:ff:ff:ff:ff")
-    arp_request_broadcast = broadcast/arp_request
-    answered_list = scapy.srp(arp_request_broadcast, timeout=3, verbose=False)[0]
+netifaces = None
+ARP = None
+Ether = None
+srp = None
 
-    clients_list = []
-    for element in answered_list:
-        client_dict = {"ip": element[1].psrc, "mac": element[1].hwsrc}
-        clients_list.append(client_dict)
-    return clients_list
+DEFAULT_TIMEOUT = 3.0
+DEFAULT_MAX_ADDRESSES = 4096
 
-def display_result(interface, results_list):
-    print(f"\nResults for {interface}:")
-    print("IP\t\t\tMAC Address\n-----------------------------------------")
 
-    # Sort the results based on IP addresses
-    sorted_results = sorted(results_list, key=lambda x: ipaddress.ip_address(x['ip']))
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="ARP-scan IPv4 networks attached to local interfaces."
+    )
+    parser.add_argument(
+        "-i",
+        "--interface",
+        action="append",
+        dest="interfaces",
+        help="scan only this interface; repeat to select multiple interfaces",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT,
+        help=f"response timeout in seconds (default: {DEFAULT_TIMEOUT:g})",
+    )
+    parser.add_argument(
+        "--max-addresses",
+        type=int,
+        default=DEFAULT_MAX_ADDRESSES,
+        help=(
+            "skip networks larger than this many addresses "
+            f"(default: {DEFAULT_MAX_ADDRESSES})"
+        ),
+    )
+    parser.add_argument(
+        "--allow-large",
+        action="store_true",
+        help="scan networks larger than --max-addresses",
+    )
+    return parser.parse_args()
 
-    for client in sorted_results:
-        print(client["ip"] + "\t\t" + client["mac"])
 
-    # Display total count of hosts found
-    print(f"\nTotal hosts found on {interface}: {len(sorted_results)}\n")
+def load_dependencies() -> None:
+    global netifaces, ARP, Ether, srp
+    try:
+        import netifaces as loaded_netifaces
+        from scapy.all import ARP as loaded_arp
+        from scapy.all import Ether as loaded_ether
+        from scapy.all import srp as loaded_srp
+    except ImportError as exc:  # pragma: no cover - depends on the local environment
+        missing = exc.name or "a required dependency"
+        raise RuntimeError(
+            f"Missing Python dependency: {missing}. Install requirements with: "
+            "python3 -m pip install scapy netifaces"
+        ) from exc
 
-def get_networks():
-    networks = {}
-    for interface in ni.interfaces():
-        addrs = ni.ifaddresses(interface)
-        if ni.AF_INET not in addrs:
+    netifaces = loaded_netifaces
+    ARP = loaded_arp
+    Ether = loaded_ether
+    srp = loaded_srp
+
+
+def require_root() -> None:
+    if hasattr(os, "geteuid") and os.geteuid() != 0:
+        raise PermissionError("raw ARP scanning requires root privileges")
+
+
+def discover_networks(
+    selected_interfaces: set[str] | None = None,
+) -> list[tuple[str, ipaddress.IPv4Network]]:
+    discovered: set[tuple[str, ipaddress.IPv4Network]] = set()
+
+    for interface in netifaces.interfaces():
+        if selected_interfaces and interface not in selected_interfaces:
             continue
-        addr_info = addrs[ni.AF_INET][0]
-        ip_addr = addr_info['addr']
-        # Skip the loopback interface
-        if ip_addr.startswith("127."):
-            continue
-        # Build the real network from the interface netmask instead of assuming /24
-        netmask = addr_info.get('netmask', '255.255.255.0')
-        network = ipaddress.ip_network(f"{ip_addr}/{netmask}", strict=False)
-        # Skip networks too large to ARP-scan in a reasonable time
-        if network.prefixlen < 16:
-            print(f"Skipping {network} on {interface}: network larger than /16")
-            continue
-        networks[interface] = str(network)
-    return networks
 
-def main():
-    networks = get_networks()
+        try:
+            ipv4_addresses = netifaces.ifaddresses(interface).get(
+                netifaces.AF_INET, []
+            )
+        except (OSError, ValueError):
+            continue
+
+        for address in ipv4_addresses:
+            ip_text = address.get("addr")
+            netmask = address.get("netmask")
+            if not ip_text or not netmask:
+                continue
+
+            try:
+                ip_address = ipaddress.ip_address(ip_text)
+                network = ipaddress.ip_network(f"{ip_text}/{netmask}", strict=False)
+            except ValueError:
+                continue
+
+            if not isinstance(ip_address, ipaddress.IPv4Address):
+                continue
+            if ip_address.is_loopback or ip_address.is_link_local:
+                continue
+
+            discovered.add((interface, network))
+
+    return sorted(discovered, key=lambda item: (item[0], item[1].network_address))
+
+
+def scan_network(
+    interface: str,
+    network: ipaddress.IPv4Network,
+    timeout: float,
+) -> list[dict[str, str]]:
+    packet = Ether(dst="ff:ff:ff:ff:ff:ff") / ARP(pdst=str(network))
+    answered = srp(
+        packet,
+        iface=interface,
+        timeout=timeout,
+        retry=1,
+        verbose=False,
+    )[0]
+
+    clients: dict[ipaddress.IPv4Address, str] = {}
+    for _, response in answered:
+        try:
+            address = ipaddress.ip_address(response.psrc)
+        except ValueError:
+            continue
+        if isinstance(address, ipaddress.IPv4Address):
+            clients[address] = response.hwsrc.lower()
+
+    return [
+        {"ip": str(address), "mac": clients[address]}
+        for address in sorted(clients)
+    ]
+
+
+def display_results(
+    interface: str,
+    network: ipaddress.IPv4Network,
+    clients: Iterable[dict[str, str]],
+) -> None:
+    rows = list(clients)
+    print(f"\nResults for {interface} ({network})")
+    print(f"{'IP address':<16} MAC address")
+    print(f"{'-' * 16} {'-' * 17}")
+    for client in rows:
+        print(f"{client['ip']:<16} {client['mac']}")
+    print(f"Hosts found: {len(rows)}")
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.timeout <= 0:
+        print("--timeout must be greater than zero", file=sys.stderr)
+        return 2
+    if args.max_addresses <= 0:
+        print("--max-addresses must be greater than zero", file=sys.stderr)
+        return 2
+
+    try:
+        load_dependencies()
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        require_root()
+    except PermissionError as exc:
+        print(f"Error: {exc}. Run with sudo.", file=sys.stderr)
+        return 1
+
+    selected_interfaces = set(args.interfaces) if args.interfaces else None
+    if selected_interfaces:
+        unknown = selected_interfaces.difference(netifaces.interfaces())
+        if unknown:
+            print(
+                f"Unknown interface(s): {', '.join(sorted(unknown))}",
+                file=sys.stderr,
+            )
+            return 2
+
+    networks = discover_networks(selected_interfaces)
     if not networks:
-        print("No scannable networks found.")
-        return
-    for interface, ip_range in networks.items():
-        print(f"Scanning {ip_range} on {interface}")
-        scan_result = scan(ip_range)
-        display_result(interface, scan_result)
+        print("No eligible IPv4 networks found.", file=sys.stderr)
+        return 1
+
+    scanned = 0
+    for interface, network in networks:
+        if network.num_addresses > args.max_addresses and not args.allow_large:
+            print(
+                f"Skipping {network} on {interface}: {network.num_addresses} addresses "
+                f"exceeds --max-addresses {args.max_addresses}",
+                file=sys.stderr,
+            )
+            continue
+
+        print(f"Scanning {network} on {interface}...")
+        try:
+            clients = scan_network(interface, network, args.timeout)
+        except PermissionError as exc:
+            print(f"Scan failed on {interface}: {exc}", file=sys.stderr)
+            continue
+        except OSError as exc:
+            print(f"Scan failed on {interface}: {exc}", file=sys.stderr)
+            continue
+
+        display_results(interface, network, clients)
+        scanned += 1
+
+    if scanned == 0:
+        print("No networks were scanned.", file=sys.stderr)
+        return 1
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/arpscanner/readme.md
+++ b/arpscanner/readme.md
@@ -1,30 +1,57 @@
 # Network ARP Scanner
 
-A Python script that ARP-scans the local network(s) attached to your machine and lists each active device's IP and MAC address, sorted by IP, with a per-interface host count.
+A Python utility that discovers active IPv4 hosts on directly connected networks and prints their IP and MAC addresses per interface.
 
-## Features
+## Improvements and behavior
 
-- Auto-detects all IPv4 interfaces (loopback excluded) and derives each one's real network from its netmask — no hardcoded subnet assumptions.
-- Skips networks larger than /16 to avoid unreasonably long scans.
-- Sorted, per-interface output with a total host count.
+- Detects IPv4 networks from each interface and its actual netmask.
+- Sends each ARP request through the interface that owns the network.
+- Supports multiple IPv4 addresses and networks per interface.
+- Deduplicates responses and sorts results numerically by IP address.
+- Skips loopback and link-local addresses.
+- Refuses unexpectedly large scans by default.
 
 ## Requirements
 
-- Python 3
-- `scapy` and `netifaces` libraries:
+- Linux or another Unix-like system with raw-packet support
+- Python 3.9 or newer
+- Root privileges
+- `scapy` and `netifaces`
 
-  ```
-  pip install scapy netifaces
-  ```
+Install the Python dependencies:
 
-- Root privileges (raw packet access).
+```bash
+python3 -m pip install scapy netifaces
+```
 
 ## Usage
 
-```
+Scan all eligible connected networks:
+
+```bash
 sudo python3 arpscanner.py
 ```
 
-## Disclaimer
+Scan one interface:
 
-Ensure you have authorization before scanning any network.
+```bash
+sudo python3 arpscanner.py --interface eth0
+```
+
+Select multiple interfaces and change the response timeout:
+
+```bash
+sudo python3 arpscanner.py -i eth0 -i bond0 --timeout 5
+```
+
+Networks larger than 4,096 addresses are skipped by default. Override the limit only when the scope is intentional:
+
+```bash
+sudo python3 arpscanner.py --max-addresses 65536 --allow-large
+```
+
+Run `python3 arpscanner.py --help` for all options.
+
+## Safety
+
+ARP scanning is limited to directly connected Layer 2 networks. Run it only on networks you own or are authorized to assess. Large scans can generate substantial broadcast traffic.


### PR DESCRIPTION
## What changed

- bind each ARP scan to the interface that owns the selected network
- support multiple networks per interface and optional interface filters
- add dependency, privilege, argument, and oversized-network safeguards
- deduplicate and numerically sort discovered hosts
- update usage and safety documentation

## Why

The previous implementation discovered networks per interface but did not pass the interface to Scapy, so a multi-homed host could send a scan through the wrong interface. It also allowed very large connected networks to be scanned without an explicit override.

## Validation

- `python3 -m py_compile arpscanner.py`
- verified `--help` without optional dependencies installed
- reviewed interface binding and address-limit paths
