### PR TITLE
Keep AutoNetDiscover interface and subnet selections paired

### DIFF
--- a/autonetdiscover/AutoNetDiscover.md
+++ b/autonetdiscover/AutoNetDiscover.md
@@ -1,57 +1,41 @@
-# README for AutoNetDiscover.sh
+# AutoNetDiscover
 
-## AutoNetDiscover.sh
+`autonetdiscover.sh` is a small interactive wrapper around `arp-scan`. It lists the IPv4 subnet attached to each active interface, keeps each subnet paired with the correct interface, and scans the selected network.
 
-### Description
+## Why the interface/subnet pairing matters
 
-AutoNetDiscover.sh is a Bash script for Debian-based systems that facilitates network discovery by scanning for active hosts within a user-selected subnet and network interface. This script is ideal for network administrators and IT professionals for tasks like network monitoring and auditing. It requires root privileges to operate.
+A host can have several interfaces, VLANs, bonds, or bridges. Selecting an interface and subnet independently can send a scan through the wrong Layer 2 segment. AutoNetDiscover presents valid pairs reported by `ip addr` and rejects mismatched non-interactive arguments.
 
-### Features
+## Requirements
 
-- Interactive selection of network interfaces and subnets.
-- Automated scanning of the chosen subnet for active hosts.
-- Outputs a list of active hosts, sorted by IP addresses.
+- Bash 4 or newer
+- `ip` from `iproute2`
+- `arp-scan`
+- Root privileges or equivalent raw-packet capabilities
 
-### Requirements
+On Debian or Ubuntu:
 
-- Bash shell environment.
-- `arp-scan` tool must be installed.
-- Root access is required to run the script.
+```bash
+sudo apt install arp-scan iproute2
+```
 
-### Usage
+## Usage
 
-1. Ensure the `arp-scan` tool is installed on your system.
+Interactive mode:
 
-2. Run the script with root privileges:
+```bash
+chmod +x autonetdiscover.sh
+sudo ./autonetdiscover.sh
+```
 
-   ```
-   sudo ./autonetdiscover.sh
-   ```
+Non-interactive mode:
 
-3. Select the desired network interface and subnet from the presented lists.
+```bash
+sudo ./autonetdiscover.sh --interface eth0 --subnet 192.0.2.10/24
+```
 
-4. The script will then scan the subnet and display the active hosts.
+The CIDR must exactly match an address/prefix currently assigned to the selected interface. Run `./autonetdiscover.sh --help` for the option summary.
 
-### Running the Script
+## Safety
 
-To execute the script, follow these steps:
-
-1. Open a terminal window.
-
-2. Navigate to the directory containing `autonetdiscover.sh`.
-
-3. Make the script executable (if not already) using:
-
-   ```
-   chmod +x autonetdiscover.sh
-   ```
-
-4. Run the script with `sudo`:
-
-   ```
-   sudo ./autonetdiscover.sh
-   ```
-
-### Important Note
-
-Network scanning can be seen as intrusive in certain environments. Always ensure you have proper authorization and are compliant with applicable policies and regulations before conducting network scans.
+Use this utility only on networks you own or are authorized to assess. ARP scanning generates broadcast traffic on the selected Layer 2 segment.

--- a/autonetdiscover/autonetdiscover.sh
+++ b/autonetdiscover/autonetdiscover.sh
@@ -1,49 +1,95 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
-# Check if the script is run as root
-if [ "$(id -u)" != "0" ]; then
-   echo "This script must be run as root" 1>&2
-   exit 1
-fi
+usage() {
+    cat <<'EOF'
+Usage: autonetdiscover.sh [--interface NAME --subnet CIDR]
 
-# Check that arp-scan is installed
-if ! command -v arp-scan &> /dev/null; then
-    echo "arp-scan is not installed. Install it with: apt install arp-scan" 1>&2
+Interactively select a local interface/subnet pair and scan it with arp-scan.
+Both --interface and --subnet must be supplied together for non-interactive use.
+EOF
+}
+
+interface=""
+subnet=""
+
+while (($#)); do
+    case "$1" in
+        -i|--interface)
+            [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 2; }
+            interface=$2
+            shift 2
+            ;;
+        -s|--subnet)
+            [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 2; }
+            subnet=$2
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+for command in ip arp-scan; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "Required command not found: $command" >&2
+        exit 1
+    fi
+done
+
+if ((EUID != 0)); then
+    echo "arp-scan requires root privileges. Run this script with sudo." >&2
     exit 1
 fi
 
-# Function to get subnets from interfaces
-get_subnets() {
-    ip -o addr show | awk '$3 == "inet" {print $4}'
-}
+mapfile -t network_pairs < <(
+    ip -o -4 addr show up scope global |
+        awk '{print $2 "|" $4}' |
+        sort -u
+)
 
-# Function to get network interfaces
-get_interfaces() {
-    ip -o link show | awk -F': ' '{print $2}' | awk '{print $1}'
-}
+if ((${#network_pairs[@]} == 0)); then
+    echo "No active, globally scoped IPv4 interfaces were found." >&2
+    exit 1
+fi
 
-# Present subnets as options
-echo "Available Subnets:"
-subnets=($(get_subnets))
-select subnet in "${subnets[@]}"; do
-    if [ -n "$subnet" ]; then
-        break
-    else
-        echo "Invalid selection. Please try again."
+if [[ -n "$interface" || -n "$subnet" ]]; then
+    if [[ -z "$interface" || -z "$subnet" ]]; then
+        echo "--interface and --subnet must be supplied together." >&2
+        exit 2
     fi
-done
 
-# Present interfaces as options
-echo "Available Interfaces:"
-interfaces=($(get_interfaces))
-select interface in "${interfaces[@]}"; do
-    if [ -n "$interface" ]; then
-        break
-    else
-        echo "Invalid selection. Please try again."
+    requested_pair="$interface|$subnet"
+    pair_found=false
+    for pair in "${network_pairs[@]}"; do
+        if [[ "$pair" == "$requested_pair" ]]; then
+            pair_found=true
+            break
+        fi
+    done
+
+    if [[ "$pair_found" != true ]]; then
+        echo "$subnet is not assigned to active interface $interface." >&2
+        exit 2
     fi
-done
+else
+    echo "Available interface/subnet pairs:"
+    PS3="Select a network to scan: "
+    select selected_pair in "${network_pairs[@]}"; do
+        if [[ -n "$selected_pair" ]]; then
+            IFS='|' read -r interface subnet <<<"$selected_pair"
+            break
+        fi
+        echo "Invalid selection. Please try again." >&2
+    done
+fi
 
-# Scan the chosen subnet for hosts and sort the output
-echo "Scanning for active hosts on $subnet using interface $interface..."
-arp-scan --interface="$interface" "$subnet" | sort -t . -k 3,3n -k 4,4n
+echo "Scanning $subnet through $interface..."
+exec arp-scan --interface="$interface" "$subnet"


### PR DESCRIPTION
## What changed

- present valid active interface/CIDR pairs instead of two independent menus
- reject mismatched non-interactive interface and subnet arguments
- add strict Bash error handling, dependency checks, and `--help`
- preserve `arp-scan` output instead of sorting headers and summary lines
- rewrite usage and safety documentation

## Why

The previous script allowed a subnet discovered on one interface to be scanned through another interface. That could produce misleading results or send traffic to the wrong Layer 2 segment.

## Validation

- `bash -n autonetdiscover.sh`
- verified `--help`
- reviewed interactive and non-interactive pairing paths
