### PR TITLE
Harden KVM and libvirt host installation

### DIFF
--- a/kvm-auto-install/install_kvm.sh
+++ b/kvm-auto-install/install_kvm.sh
@@ -1,38 +1,154 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
-# Check for CPU virtualization support
-if grep -Eq 'vmx|svm' /proc/cpuinfo; then
-    echo "Installer can continue: CPU supports virtualization."
-else
-    echo "CPU does not support virtualization. Exiting."
+with_gui=false
+skip_groups=false
+
+usage() {
+    cat <<'EOF'
+Usage: install_kvm.sh [options]
+
+Install a KVM/QEMU and libvirt host on Debian or Ubuntu.
+
+Options:
+  --with-gui     Install virt-manager and virt-viewer.
+  --skip-groups  Do not add the invoking user to libvirt and kvm groups.
+  -h, --help     Show this help text.
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+        --with-gui)
+            with_gui=true
+            shift
+            ;;
+        --skip-groups)
+            skip_groups=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+trap 'echo "KVM installation failed near line $LINENO." >&2' ERR
+
+if [[ ! -r /etc/os-release ]]; then
+    echo "/etc/os-release is unavailable; cannot identify the distribution." >&2
     exit 1
 fi
 
-# Update packages and install KVM and related tools
-echo "Installing KVM and related tools..."
-sudo apt update
-sudo apt install -y qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virt-manager virt-viewer cpu-checker
+# shellcheck disable=SC1091
+. /etc/os-release
+case "${ID:-}" in
+    debian|ubuntu) ;;
+    *)
+        echo "Unsupported distribution: ${PRETTY_NAME:-${ID:-unknown}}" >&2
+        echo "This installer supports Debian and Ubuntu." >&2
+        exit 1
+        ;;
+esac
 
-# Add the current user to the libvirt group
-echo "Adding $(whoami) to the libvirt group..."
-sudo usermod -aG libvirt "$(whoami)"
+for command in apt-get dpkg systemctl virsh; do
+    if [[ "$command" == virsh ]]; then
+        continue
+    fi
+    command -v "$command" >/dev/null 2>&1 || {
+        echo "Required command not found: $command" >&2
+        exit 1
+    }
+done
 
-# Inform the user
-echo "User $(whoami) added to libvirt group."
-
-# Check KVM status
-echo "Checking KVM status with kvm-ok..."
-kvm-ok
-
-# Check libvirtd service status
-echo "Checking libvirtd service status..."
-serviceStatus=$(sudo systemctl status libvirtd --no-pager | grep "Active:")
-
-echo "$serviceStatus"
-
-# Check if libvirtd is active and running
-if [[ $serviceStatus == *"active (running)"* ]]; then
-    echo "libvirtd is active and running."
+if ((EUID == 0)); then
+    sudo_cmd=()
 else
-    echo "libvirtd is not running. Please check the service status."
+    command -v sudo >/dev/null 2>&1 || {
+        echo "sudo is required when the script is not run as root." >&2
+        exit 1
+    }
+    sudo_cmd=(sudo)
 fi
+
+architecture=$(dpkg --print-architecture)
+case "$architecture" in
+    amd64)
+        qemu_package=qemu-system-x86
+        if ! grep -Eq '(^|[[:space:]])(vmx|svm)([[:space:]]|$)' /proc/cpuinfo && [[ ! -e /dev/kvm ]]; then
+            echo "Hardware virtualization is unavailable. Enable Intel VT-x/AMD-V in firmware or expose virtualization to this guest." >&2
+            exit 1
+        fi
+        ;;
+    arm64)
+        qemu_package=qemu-system-arm
+        if [[ ! -e /dev/kvm ]]; then
+            echo "/dev/kvm is unavailable; hardware virtualization is not exposed to this system." >&2
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Unsupported architecture: $architecture" >&2
+        exit 1
+        ;;
+esac
+
+packages=(
+    "$qemu_package"
+    qemu-utils
+    libvirt-daemon-system
+    libvirt-clients
+    bridge-utils
+)
+
+if [[ "$with_gui" == true ]]; then
+    packages+=(virt-manager virt-viewer)
+fi
+
+echo "Installing KVM/QEMU and libvirt packages..."
+"${sudo_cmd[@]}" apt-get update
+"${sudo_cmd[@]}" apt-get install -y "${packages[@]}"
+
+service_started=false
+for service in libvirtd.service virtqemud.service; do
+    if systemctl list-unit-files "$service" --no-legend 2>/dev/null | grep -q "^$service"; then
+        echo "Enabling and starting $service..."
+        "${sudo_cmd[@]}" systemctl enable --now "$service"
+        service_started=true
+        break
+    fi
+done
+
+if [[ "$service_started" != true ]]; then
+    echo "No supported libvirt service unit was found after installation." >&2
+    exit 1
+fi
+
+invoking_user=${SUDO_USER:-${USER:-}}
+if [[ "$skip_groups" != true && -n "$invoking_user" && "$invoking_user" != root ]]; then
+    for group in libvirt kvm; do
+        if getent group "$group" >/dev/null 2>&1; then
+            echo "Adding $invoking_user to $group..."
+            "${sudo_cmd[@]}" usermod -aG "$group" "$invoking_user"
+        fi
+    done
+    echo "Log out and back in before using libvirt without sudo."
+fi
+
+if [[ -e /dev/kvm ]]; then
+    echo "KVM device:"
+    ls -l /dev/kvm
+else
+    echo "Warning: /dev/kvm is still unavailable after package installation." >&2
+fi
+
+echo "Validating the system libvirt connection..."
+"${sudo_cmd[@]}" virsh -c qemu:///system list --all
+
+echo "KVM/libvirt installation completed successfully."

--- a/kvm-auto-install/readme.md
+++ b/kvm-auto-install/readme.md
@@ -1,44 +1,57 @@
-# KVM Installation Script
+# KVM/QEMU and libvirt Installer
 
-This repository contains a script for setting up a KVM (Kernel-based Virtual Machine) environment on a Debian-based system. It checks for CPU virtualization support, installs necessary packages, adds the user to the `libvirt` group, and verifies the installation.
+This script prepares a Debian or Ubuntu host for hardware-accelerated virtualization with KVM, QEMU, and libvirt.
 
-## Prerequisites
-- A Debian-based Linux distribution.
-- A CPU that supports hardware virtualization (Intel VT-x or AMD-V).
-- Sudo privileges on the system.
+## Behavior
 
-## Installation
-1. **Download the Script**:
-   Download `install_kvm.sh` to your system (or clone this repository).
-2. **Make the Script Executable**:
-   ```bash
-   chmod +x install_kvm.sh
-   ```
-3. **Run the Script**:
-   ```bash
-   ./install_kvm.sh
-   ```
-   Follow the on-screen instructions. The script will ask for your sudo password.
+- Checks that hardware virtualization is exposed before installing packages.
+- Supports `amd64` and `arm64` package selections.
+- Installs a headless virtualization stack by default.
+- Optionally installs `virt-manager` and `virt-viewer`.
+- Starts either `libvirtd.service` or the modular `virtqemud.service`, depending on the distribution.
+- Adds the invoking non-root user to available `libvirt` and `kvm` groups unless disabled.
+- Validates the system libvirt connection with `virsh`.
 
-## What the Script Does
-1. Checks if your CPU supports virtualization.
-2. Installs KVM, QEMU, and other necessary tools.
-3. Adds your user to the `libvirt` group.
-4. Checks the status of the `libvirtd` service.
+## Requirements
 
-## Post-Installation
-- You may need to log out and log back in for the group changes to take effect.
-- Run `kvm-ok` to verify that KVM is set up correctly.
-- Use `virsh` or `virt-manager` to manage your virtual machines.
+- Debian or Ubuntu
+- Intel VT-x, AMD-V, or ARM virtualization support exposed by the kernel/hypervisor
+- Root access or `sudo`
+- `systemd`
 
-## Troubleshooting
-If you encounter issues, check the following:
-- Ensure your CPU supports hardware virtualization.
-- Verify that you have sudo privileges.
-- Check the `libvirtd` service status if the script indicates it's not running.
+When running inside a virtual machine, the outer hypervisor must expose nested virtualization.
 
-## Contributing
-Contributions to improve the script or documentation are welcome. Please submit a pull request or open an issue if you have suggestions or find a bug.
+## Usage
 
-## License
-This project is open-source and available under the [MIT License](../LICENSE).
+Install the headless stack:
+
+```bash
+chmod +x install_kvm.sh
+./install_kvm.sh
+```
+
+Include desktop management tools:
+
+```bash
+./install_kvm.sh --with-gui
+```
+
+Skip user group changes:
+
+```bash
+./install_kvm.sh --skip-groups
+```
+
+After group membership changes, log out and back in before using `virsh` as a non-root user.
+
+## Validation
+
+Useful follow-up commands:
+
+```bash
+virsh -c qemu:///system list --all
+systemctl status libvirtd --no-pager
+systemctl status virtqemud --no-pager
+```
+
+Only one of the two service units may exist on a given system.


### PR DESCRIPTION
## What changed

- validate Debian/Ubuntu and amd64/arm64 support
- detect whether hardware virtualization is exposed before installation
- install a headless QEMU/libvirt stack by default with optional GUI tools
- support both `libvirtd` and modular `virtqemud` service layouts
- add the invoking user to available `libvirt` and `kvm` groups safely
- validate the system libvirt connection with `virsh`
- remove the Ubuntu-specific `kvm-ok` dependency

## Why

The previous installer assumed one package and service layout, installed desktop tools on every host, and could add the wrong user when invoked with sudo. It also treated an informational service check as success even when libvirt was not running.

## Validation

- `bash -n install_kvm.sh`
- verified `--help`
- reviewed architecture, service fallback, group, and validation paths
