### PR TITLE
Harden MultiHostCommander remote execution

### DIFF
--- a/multihostcommanders/MultiHostCommander.md
+++ b/multihostcommanders/MultiHostCommander.md
@@ -1,42 +1,67 @@
-### README for MultiHostCommander
+# MultiHostCommander
 
-------
+`multihostcommander.sh` sends a local command file to a remote shell on each SSH host in a host file. It continues after individual failures and prints a final success/failure summary.
 
-#### Description
+## Safety defaults
 
-This script allows users to execute a set of commands on multiple Debian hosts via SSH. It reads commands and host details from user-provided files, streamlining batch operations on servers.
+- SSH batch mode is enabled, so jobs fail instead of hanging on password prompts.
+- Existing host keys must already be trusted by default.
+- Use `--accept-new` to trust previously unseen keys while still rejecting changed keys.
+- The command file is streamed over standard input rather than embedded in an SSH command string, preserving multiline scripts and reducing quoting problems.
 
-------
+## Requirements
 
-#### Usage
+- Bash 4 or newer on the control host
+- OpenSSH client
+- SSH key-based authentication for each target
+- A compatible remote shell; `sh` is the default
 
-1. **Prepare Command File**: Create a text file containing the commands you want to execute on the Debian hosts. Each command should be on a separate line.
-2. **Prepare Host File**: Create a text file listing the Debian hosts. Each host should be on a new line.
-3. **Execute the Script**: Run the script by typing `./scriptname.sh` in the terminal. When prompted, enter the filenames for the command and host files.
-4. **Output**: The script connects to each host via SSH and executes the provided commands, displaying the output for each host.
+## Input files
 
-------
+`hosts.txt`:
 
-#### Requirements
-
-- SSH key-based authentication must be set up for each target host.
-- The script file should have executable permissions (`chmod +x multihostcommander.sh`).
-
-------
-
-#### Note
-
-- Ensure that the command and host files are correctly formatted and the paths provided during the prompt are accurate.
-- Blank lines and lines starting with `#` in the host file are skipped.
-- This script assumes that SSH key-based authentication is configured for all the target hosts.
-- New hosts are trusted automatically on first connection (`StrictHostKeyChecking=accept-new`), but connections are refused if a known host's key has changed.
-
-------
-
-#### Script File Permissions
-
-To make the script executable, run:
-
+```text
+# Web tier
+admin@web01.example.com
+admin@web02.example.com
 ```
+
+`commands.sh`:
+
+```sh
+hostname
+uname -r
+df -h /
+```
+
+Blank lines and comments in the host file are ignored. Duplicate hosts are removed.
+
+## Usage
+
+```bash
 chmod +x multihostcommander.sh
+./multihostcommander.sh \
+  --hosts hosts.txt \
+  --commands commands.sh
 ```
+
+Trust new host keys during first use:
+
+```bash
+./multihostcommander.sh \
+  --hosts hosts.txt \
+  --commands commands.sh \
+  --accept-new
+```
+
+Use Bash remotely and increase the connection timeout:
+
+```bash
+./multihostcommander.sh \
+  --hosts hosts.txt \
+  --commands commands.sh \
+  --shell bash \
+  --connect-timeout 20
+```
+
+Review command files carefully before running them across multiple systems. The utility intentionally executes the complete file on every listed host.

--- a/multihostcommanders/multihostcommander.sh
+++ b/multihostcommanders/multihostcommander.sh
@@ -1,42 +1,139 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -u -o pipefail
 
-# Function to perform the SSH operation
-execute_ssh() {
-    local host=$1
-    local commands=$2
+host_file=""
+command_file=""
+remote_shell=sh
+connect_timeout=10
+accept_new=false
 
-    echo "--$host"
-    # -n prevents ssh from consuming the host list on stdin
-    # accept-new trusts unseen hosts but still rejects changed host keys
-    ssh -n -o StrictHostKeyChecking=accept-new "$host" "$commands"
+usage() {
+    cat <<'EOF'
+Usage: multihostcommander.sh [options]
+
+Execute a local command file on each SSH host listed in a host file.
+
+Options:
+  -H, --hosts FILE       Host file (one user@host or SSH alias per line)
+  -C, --commands FILE    Commands sent to the remote shell
+  --shell NAME           Remote shell command (default: sh)
+  --connect-timeout SEC  SSH connection timeout (default: 10)
+  --accept-new           Trust previously unseen host keys
+  -h, --help             Show this help text
+EOF
 }
 
-# Prompt for the filename containing commands
-echo "Enter the filename containing the commands:"
-read command_file
+while (($#)); do
+    case "$1" in
+        -H|--hosts)
+            [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 2; }
+            host_file=$2
+            shift 2
+            ;;
+        -C|--commands)
+            [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 2; }
+            command_file=$2
+            shift 2
+            ;;
+        --shell)
+            [[ $# -ge 2 && $2 =~ ^[A-Za-z0-9_./-]+$ ]] || {
+                echo "Invalid remote shell value." >&2
+                exit 2
+            }
+            remote_shell=$2
+            shift 2
+            ;;
+        --connect-timeout)
+            [[ $# -ge 2 && $2 =~ ^[1-9][0-9]*$ ]] || {
+                echo "Connection timeout must be a positive integer." >&2
+                exit 2
+            }
+            connect_timeout=$2
+            shift 2
+            ;;
+        --accept-new)
+            accept_new=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
 
-# Check if the command file exists and is not empty
-if [[ ! -s "$command_file" ]]; then
-    echo "Command file is empty or does not exist."
+command -v ssh >/dev/null 2>&1 || {
+    echo "OpenSSH client is required." >&2
     exit 1
+}
+
+if [[ -z "$host_file" && -t 0 ]]; then
+    read -r -p "Host file: " host_file
+fi
+if [[ -z "$command_file" && -t 0 ]]; then
+    read -r -p "Command file: " command_file
 fi
 
-# Read commands from the file
-commands=$(<"$command_file")
-
-# Prompt for the filename containing hosts
-echo "Enter the filename containing the hosts:"
-read host_file
-
-# Check if the host file exists and is not empty
 if [[ ! -s "$host_file" ]]; then
-    echo "Host file is empty or does not exist."
+    echo "Host file is missing or empty: $host_file" >&2
+    exit 1
+fi
+if [[ ! -s "$command_file" ]]; then
+    echo "Command file is missing or empty: $command_file" >&2
     exit 1
 fi
 
-# Read hosts from the file and execute commands on each
-while IFS= read -r host; do
-    # Skip blank lines and comments
-    [[ -z "$host" || "$host" == \#* ]] && continue
-    execute_ssh "$host" "$commands"
+hosts=()
+declare -A seen=()
+while IFS= read -r host || [[ -n "$host" ]]; do
+    host=${host%$'\r'}
+    host=${host%%#*}
+    read -r host _ <<<"$host"
+    [[ -n "$host" ]] || continue
+    if [[ "$host" == -* ]]; then
+        echo "Refusing host value that begins with '-': $host" >&2
+        exit 2
+    fi
+    if [[ -z "${seen[$host]+x}" ]]; then
+        seen[$host]=1
+        hosts+=("$host")
+    fi
 done < "$host_file"
+
+if ((${#hosts[@]} == 0)); then
+    echo "No usable hosts were found in $host_file." >&2
+    exit 1
+fi
+
+ssh_options=(
+    -T
+    -o BatchMode=yes
+    -o ConnectTimeout="$connect_timeout"
+)
+if [[ "$accept_new" == true ]]; then
+    ssh_options+=(-o StrictHostKeyChecking=accept-new)
+else
+    ssh_options+=(-o StrictHostKeyChecking=yes)
+fi
+
+failures=()
+for host in "${hosts[@]}"; do
+    printf '\n===== %s =====\n' "$host"
+    if ! ssh "${ssh_options[@]}" "$host" "$remote_shell -s" < "$command_file"; then
+        failures+=("$host")
+        echo "Command execution failed on $host." >&2
+    fi
+done
+
+printf '\nSucceeded: %d\n' "$((${#hosts[@]} - ${#failures[@]}))"
+printf 'Failed: %d\n' "${#failures[@]}"
+
+if ((${#failures[@]} > 0)); then
+    printf 'Failed hosts: %s\n' "${failures[*]}" >&2
+    exit 1
+fi


### PR DESCRIPTION
## What changed

- accept explicit host and command files with a documented CLI
- stream the command file to a configurable remote shell
- enable SSH batch mode and connection timeouts
- require known host keys by default with opt-in `accept-new`
- ignore comments, remove duplicates, continue after failures, and summarize results

## Why

The previous implementation embedded the entire command file in one SSH command string and automatically trusted new host keys. That made multiline quoting brittle and weakened the default trust posture.

## Validation

- `bash -n multihostcommander.sh`
- verified `--help`
- reviewed host parsing, SSH options, streamed input, and failure aggregation
