### PR TITLE
Install Plex through the current official apt repository

### DIFF
--- a/plexmediaserver/install_plex.sh
+++ b/plexmediaserver/install_plex.sh
@@ -1,38 +1,75 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
-set -o pipefail
+trap 'echo "Plex Media Server installation failed near line $LINENO." >&2' ERR
 
-# Update and install necessary packages
-sudo apt-get update
-sudo apt-get install -y curl jq
-
-# Fetch the latest Plex Media Server URL for Debian
-echo "Looking up the latest Plex Media Server release..."
-PLEX_JSON=$(curl -fsSL https://plex.tv/api/downloads/5.json)
-PLEX_URL=$(echo "$PLEX_JSON" | jq -r '.computer.Linux.releases[] | select(.build=="linux-x86_64") | select(.distro=="debian") | .url')
-
-if [ -z "$PLEX_URL" ] || [ "$PLEX_URL" = "null" ]; then
-    echo "Error: could not determine the Plex download URL." 1>&2
+if [[ ! -r /etc/os-release ]]; then
+    echo "/etc/os-release is unavailable; cannot identify the distribution." >&2
     exit 1
 fi
 
-# Download the latest Plex Media Server package
-DEB_FILE=$(mktemp /tmp/plexmediaserver.XXXXXX.deb)
-echo "Downloading Plex Media Server..."
-curl -fSL "$PLEX_URL" --output "$DEB_FILE"
+# shellcheck disable=SC1091
+. /etc/os-release
+if [[ "${ID:-}" != debian && "${ID:-}" != ubuntu && " ${ID_LIKE:-} " != *" debian "* ]]; then
+    echo "Unsupported distribution: ${PRETTY_NAME:-${ID:-unknown}}" >&2
+    echo "This installer supports Debian-based systems with apt." >&2
+    exit 1
+fi
 
-# Install Plex Media Server
-echo "Installing Plex Media Server..."
-sudo dpkg -i "$DEB_FILE" || sudo apt-get -f install -y
-rm -f "$DEB_FILE"
+for command in apt-get install gpg; do
+    if [[ "$command" == gpg ]]; then
+        continue
+    fi
+    command -v "$command" >/dev/null 2>&1 || {
+        echo "Required command not found: $command" >&2
+        exit 1
+    }
+done
 
-# Enable and start Plex Media Server
-echo "Enabling and starting Plex Media Server..."
-sudo systemctl enable plexmediaserver
-sudo systemctl start plexmediaserver
+if ((EUID == 0)); then
+    sudo_cmd=()
+else
+    command -v sudo >/dev/null 2>&1 || {
+        echo "sudo is required when the script is not run as root." >&2
+        exit 1
+    }
+    sudo_cmd=(sudo)
+fi
 
-# Check the status of Plex Media Server
-echo "Checking the status of Plex Media Server..."
-sudo systemctl status plexmediaserver --no-pager
+key_source=$(mktemp)
+key_binary=$(mktemp)
+trap 'rm -f "$key_source" "$key_binary"' EXIT
 
-echo "Installation complete. You can access Plex at http://<Your-Server-IP>:32400/web"
+echo "Installing repository prerequisites..."
+"${sudo_cmd[@]}" apt-get update
+"${sudo_cmd[@]}" apt-get install -y ca-certificates curl gnupg
+
+echo "Installing Plex's v2 repository signing key..."
+curl -fsSL https://downloads.plex.tv/plex-keys/PlexSign.v2.key -o "$key_source"
+gpg --batch --yes --dearmor --output "$key_binary" "$key_source"
+"${sudo_cmd[@]}" install -m 0755 -d /etc/apt/keyrings
+"${sudo_cmd[@]}" install -m 0644 "$key_binary" /etc/apt/keyrings/plexmediaserver.v2.gpg
+
+echo "Removing superseded Plex apt source files..."
+"${sudo_cmd[@]}" find /etc/apt/sources.list.d -maxdepth 1 -type f \
+    \( -name 'plex*.list' -o -name 'plex*.sources' \) -delete
+
+echo "Configuring Plex's official apt repository..."
+echo "deb [signed-by=/etc/apt/keyrings/plexmediaserver.v2.gpg] https://repo.plex.tv/deb/ public main" |
+    "${sudo_cmd[@]}" tee /etc/apt/sources.list.d/plex.list >/dev/null
+
+"${sudo_cmd[@]}" apt-get update
+"${sudo_cmd[@]}" apt-get install -y plexmediaserver
+
+if command -v systemctl >/dev/null 2>&1; then
+    echo "Enabling and starting Plex Media Server..."
+    "${sudo_cmd[@]}" systemctl enable --now plexmediaserver
+    "${sudo_cmd[@]}" systemctl is-active --quiet plexmediaserver
+fi
+
+server_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+server_ip=${server_ip:-127.0.0.1}
+
+echo "Plex Media Server installation completed successfully."
+echo "Open http://${server_ip}:32400/web to finish setup."
+echo "The plex service account must have read and execute access to your media paths."

--- a/plexmediaserver/readme.md
+++ b/plexmediaserver/readme.md
@@ -1,39 +1,51 @@
-# Plex Media Server Installation Script for Debian
+# Plex Media Server Installer for Debian-Based Systems
 
-This script downloads and installs the latest Plex Media Server release on a Debian (x86_64) system, then enables and starts the service.
+This script configures Plex's official apt repository and installs Plex Media Server on Debian, Ubuntu, and compatible Debian-based systems.
 
-## What the Script Does
+## Why it uses the apt repository
 
-1. Installs `curl` and `jq` if needed.
-2. Queries Plex's official download API (`plex.tv/api/downloads/5.json`) for the latest Debian x86_64 package URL.
-3. Downloads the `.deb` package to a temporary file.
-4. Installs the package (resolving dependencies if necessary) and cleans up the download.
-5. Enables and starts the `plexmediaserver` systemd service.
-6. Shows the service status.
+Plex changed its Linux repositories beginning with Plex Media Server 1.43.0. The installer uses the current v2 signing key and official repository so future public releases can be installed through normal `apt update` and `apt upgrade` workflows.
 
-## Prerequisites
+## What the script does
 
-- A Debian-based x86_64 system with internet access.
-- Sudo privileges for the executing user.
+1. Installs `ca-certificates`, `curl`, and `gnupg`.
+2. Downloads and installs Plex's v2 repository signing key.
+3. Removes superseded Plex source-list files.
+4. Configures `https://repo.plex.tv/deb/` with a dedicated keyring.
+5. Installs or upgrades the `plexmediaserver` package.
+6. Enables and starts the systemd service when available.
+7. Prints a local Plex Web setup URL.
+
+## Requirements
+
+- A Debian-based system with `apt`
+- Internet access
+- Root access or `sudo`
 
 ## Usage
 
-```
+```bash
 chmod +x install_plex.sh
 ./install_plex.sh
 ```
 
-After installation, open a browser and finish setup at:
+After installation, open the URL printed by the script or browse locally to:
 
+```text
+http://127.0.0.1:32400/web
 ```
-http://<Your-Server-IP>:32400/web
+
+## Media permissions
+
+Plex Media Server runs as the `plex` service account by default. The account needs read permission on media files and read/execute permission on every parent directory in the path. Do not solve permission problems by making an entire media tree world-writable.
+
+## Updates
+
+Once the repository is configured, update Plex with the normal package workflow:
+
+```bash
+sudo apt update
+sudo apt upgrade
 ```
 
-## Notes
-
-- The script always installs the latest **public** release. Plex Pass beta builds require a Plex Pass token and are not handled by this script.
-- Re-running the script upgrades an existing installation to the latest version.
-
-## Disclaimer
-
-This script is provided "as is", without warranty of any kind. Use it at your own risk.
+This installs public releases from the Plex repository. Plex Pass beta-channel selection is outside this script's scope.


### PR DESCRIPTION
## What changed

- replace the downloads JSON and temporary `.deb` workflow with Plex's official apt repository
- install Plex's current v2 signing key in a dedicated keyring
- remove superseded Plex source-list files before configuring the current repository
- support upgrades through normal apt workflows
- add strict error handling, distro validation, service validation, and media-permission guidance

## Why

Plex changed its supported Linux repositories beginning with Plex Media Server 1.43.0. The previous script fetched a one-off package from the downloads API, which did not configure ongoing package updates and depended on a fixed API response shape.

## Validation

- `bash -n install_plex.sh`
- implementation checked against Plex's official repository instructions updated March 18, 2026
- reviewed keyring, source replacement, package, service, and cleanup paths
