### PR TITLE
Use Windows Storage health and reliability counters

### DIFF
--- a/powershell/smart-status-check-readme.md
+++ b/powershell/smart-status-check-readme.md
@@ -1,37 +1,45 @@
-## PowerShell Script for SMART Data Retrieval
+# Windows Physical Disk Health Check
 
-### Description
+`smart-status-check.ps1` is an interactive PowerShell utility that displays Windows Storage health information and reliability counters for a selected physical disk.
 
-This PowerShell script provides an easy and interactive way to retrieve SMART (Self-Monitoring, Analysis, and Reporting Technology) data from hard drives on a Windows system. It lists all connected drives and allows the user to select a drive by its index number. After selection, the script displays the SMART status and detailed SMART data for the chosen drive.
+## Data sources
 
-### Features
+The script uses the built-in Windows Storage module:
 
-- **Drive Listing**: Automatically lists all physical drives connected to the system with their Device IDs and models.
-- **Interactive Selection**: Users can select a drive by simply entering its index number.
-- **SMART Status Retrieval**: Retrieves basic SMART status, indicating the health of the selected drive.
-- **Detailed SMART Data**: Provides more in-depth SMART data for a comprehensive understanding of the drive's condition.
-- **Error Handling**: Includes basic error handling for invalid selections and cases where SMART data is not available.
+- `Get-PhysicalDisk` for inventory, health, operational status, bus type, media type, and size
+- `Get-StorageReliabilityCounter` for controller-reported temperature, wear, power-on hours, error counters, latency maxima, and cycle counts
 
-### Prerequisites
+These counters are related to SMART/device telemetry but are not a raw decoder for every vendor-specific SMART attribute.
 
-- Windows operating system.
-- Windows PowerShell 5.1 or PowerShell 7+ (the script uses `Get-CimInstance`, which works in both).
-- Administrative privileges might be required depending on the system's configuration.
+## Requirements
 
-### Usage
+- Windows 10/11 or Windows Server with the Storage module
+- Windows PowerShell 5.1 or PowerShell 7+
+- Administrative PowerShell recommended for the broadest controller access
 
-1. Download the `smart-status-check.ps1` script.
-2. Run PowerShell as an administrator.
-3. Navigate to the script's location and execute it by entering `.\smart-status-check.ps1`.
-4. Follow the on-screen prompts to select a drive and view its SMART data.
+## Usage
 
-### Notes
+Interactive selection:
 
-- The script's ability to retrieve SMART data depends on the system's hardware, drivers, and Windows version.
-- In some cases, the script may not be able to retrieve SMART data due to limitations or lack of support from the system's storage controller or drivers.
-- For comprehensive drive health monitoring, consider using specialized third-party tools like CrystalDiskInfo or GSmartControl.
+```powershell
+.\smart-status-check.ps1
+```
 
-### Release Notes
+Select a disk non-interactively by the displayed index:
 
-- Initial release: Basic functionality for listing drives and retrieving SMART data.
-- Future updates may include enhanced compatibility, additional features, and improved error handling.
+```powershell
+.\smart-status-check.ps1 -DiskIndex 0
+```
+
+## Exit codes
+
+- `0` — the selected disk is reported healthy
+- `1` — enumeration, platform, or command failure
+- `2` — invalid selection or Windows reports a degraded/non-OK disk state
+
+## Limitations
+
+- USB bridges, RAID controllers, virtual disks, and some vendor drivers may not expose reliability counters.
+- Missing counters do not prove a disk is healthy.
+- Windows health status should be considered alongside backups, vendor diagnostics, event logs, and application-level symptoms.
+- Replace failing or suspect media promptly; this utility is not a substitute for current backups.

--- a/powershell/smart-status-check.ps1
+++ b/powershell/smart-status-check.ps1
@@ -1,34 +1,113 @@
-# List all drives and their Device IDs
-# (Get-CimInstance works in both Windows PowerShell 5.1 and PowerShell 7+)
-$drives = @(Get-CimInstance -ClassName Win32_DiskDrive | Select-Object DeviceID, Model)
-$index = 0
-$drives | ForEach-Object { Write-Host "${index}: $($_.Model) - $($_.DeviceID)"; $index++ }
+[CmdletBinding()]
+param(
+    [ValidateRange(-1, 4096)]
+    [int]$DiskIndex = -1
+)
 
-# Ask the user to select a drive by its index number
-$selectedDriveIndex = Read-Host "Please select the drive number you want to check"
+$ErrorActionPreference = 'Stop'
 
-# Validate the input (Read-Host returns a string, so cast before comparing)
-if ($selectedDriveIndex -match '^\d+$' -and [int]$selectedDriveIndex -lt $drives.Count) {
-    $selectedDrive = $drives[[int]$selectedDriveIndex]
-    Write-Host "You selected: $($selectedDrive.Model) - $($selectedDrive.DeviceID)"
-
-    # Retrieve and display the SMART status for the selected drive
-    $smartStatus = Get-CimInstance -Namespace root/wmi -ClassName MSStorageDriver_FailurePredictStatus -ErrorAction SilentlyContinue |
-        Where-Object { $_.InstanceName -like "*$($selectedDrive.DeviceID.TrimStart('\', '.'))*" }
-    if ($smartStatus) {
-        $smartStatus | Format-Table -AutoSize
-    } else {
-        Write-Host "No SMART status data found for the selected drive."
-    }
-
-    # Retrieve and display detailed SMART data for the selected drive (optional)
-    $smartDetails = Get-CimInstance -Namespace root/wmi -ClassName MSStorageDriver_FailurePredictData -ErrorAction SilentlyContinue |
-        Where-Object { $_.InstanceName -like "*$($selectedDrive.DeviceID.TrimStart('\', '.'))*" }
-    if ($smartDetails) {
-        $smartDetails | Format-Table -AutoSize
-    } else {
-        Write-Host "No detailed SMART data found for the selected drive."
-    }
-} else {
-    Write-Host "Invalid selection."
+if ($env:OS -ne 'Windows_NT') {
+    Write-Error 'This script requires Windows.'
+    exit 1
 }
+
+foreach ($commandName in 'Get-PhysicalDisk', 'Get-StorageReliabilityCounter') {
+    if (-not (Get-Command $commandName -ErrorAction SilentlyContinue)) {
+        Write-Error "Required Storage module command is unavailable: $commandName"
+        exit 1
+    }
+}
+
+try {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+    $isAdministrator = $principal.IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator
+    )
+    if (-not $isAdministrator) {
+        Write-Warning 'Some controllers expose health counters only to an elevated PowerShell session.'
+    }
+} catch {
+    Write-Verbose "Could not determine elevation status: $($_.Exception.Message)"
+}
+
+try {
+    $disks = @(
+        Get-PhysicalDisk |
+            Sort-Object DeviceId, FriendlyName
+    )
+} catch {
+    Write-Error "Unable to enumerate physical disks: $($_.Exception.Message)"
+    exit 1
+}
+
+if ($disks.Count -eq 0) {
+    Write-Error 'No physical disks were returned by the Windows Storage provider.'
+    exit 1
+}
+
+Write-Host 'Available physical disks:'
+for ($index = 0; $index -lt $disks.Count; $index++) {
+    $disk = $disks[$index]
+    $sizeGiB = if ($disk.Size) { [math]::Round($disk.Size / 1GB, 1) } else { 'Unknown' }
+    Write-Host (
+        '[{0}] {1} | {2} GiB | {3} | Health: {4}' -f
+        $index,
+        $disk.FriendlyName,
+        $sizeGiB,
+        $disk.BusType,
+        $disk.HealthStatus
+    )
+}
+
+if ($DiskIndex -lt 0) {
+    $selection = Read-Host 'Select a disk index'
+    $parsedIndex = 0
+    if (-not [int]::TryParse($selection, [ref]$parsedIndex)) {
+        Write-Error 'Disk selection must be an integer.'
+        exit 2
+    }
+    $DiskIndex = $parsedIndex
+}
+
+if ($DiskIndex -lt 0 -or $DiskIndex -ge $disks.Count) {
+    Write-Error "Disk index $DiskIndex is outside the valid range 0-$($disks.Count - 1)."
+    exit 2
+}
+
+$selectedDisk = $disks[$DiskIndex]
+
+Write-Host "`nSelected disk"
+$selectedDisk |
+    Select-Object DeviceId, FriendlyName, SerialNumber, Manufacturer, Model,
+        MediaType, BusType, HealthStatus, OperationalStatus, Size |
+    Format-List
+
+try {
+    $reliability = $selectedDisk | Get-StorageReliabilityCounter -ErrorAction Stop
+    Write-Host 'Storage reliability counters'
+    $reliability |
+        Select-Object Temperature, TemperatureMax, Wear, PowerOnHours,
+            ReadErrorsTotal, ReadErrorsCorrected, ReadErrorsUncorrected,
+            WriteErrorsTotal, WriteErrorsCorrected, WriteErrorsUncorrected,
+            ReadLatencyMax, WriteLatencyMax, FlushLatencyMax,
+            StartStopCycleCount, LoadUnloadCycleCount |
+        Format-List
+} catch {
+    Write-Warning (
+        'Reliability counters are unavailable for this disk/controller: {0}' -f
+        $_.Exception.Message
+    )
+}
+
+$healthProblem = $selectedDisk.HealthStatus -and $selectedDisk.HealthStatus -ne 'Healthy'
+$operationalProblem = @($selectedDisk.OperationalStatus) |
+    Where-Object { $_ -notin @('OK', 'Online') }
+
+if ($healthProblem -or $operationalProblem) {
+    Write-Warning 'Windows reports a non-healthy or non-OK state for the selected disk.'
+    exit 2
+}
+
+Write-Host 'Windows reports the selected disk as healthy.'
+exit 0


### PR DESCRIPTION
## What changed

- replace fragile WMI instance-name matching with the supported Windows Storage module
- display physical-disk inventory, health, operational status, media, bus, size, and serial data
- retrieve controller-supported reliability counters such as temperature, wear, power-on hours, and errors
- support interactive or `-DiskIndex` selection
- add platform, command, index, and health-state exit handling
- clarify that the utility is not a raw vendor SMART decoder

## Why

The previous script attempted to match `Win32_DiskDrive.DeviceID` values such as `PhysicalDrive0` against `MSStorageDriver` instance names. Those identifiers do not reliably correspond, so valid disks could show no data or the wrong data.

## Validation

- reviewed against current Microsoft documentation for `Get-PhysicalDisk` and `Get-StorageReliabilityCounter`
- performed delimiter and structure sanity checks
- not executed against Windows hardware in this environment; controller-specific behavior still needs a Windows smoke test
